### PR TITLE
Removing https from docs.udst.org links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # udst-docs
 
-This repo generates the landing page for UDST documentation, hosted at https://docs.udst.org and https://udst-docs.readthedocs.io.
+This repo generates the landing page for UDST documentation, hosted at http://docs.udst.org and https://udst-docs.readthedocs.io.
 
 ### How it works
 
@@ -26,4 +26,4 @@ Hosting settings are at https://readthedocs.org/projects/udst-docs/. If you don'
 
 The DNS settings for the docs.udst.org subdomain contain a CNAME record redirecting traffic to readthedocs.io. ReadTheDocs handles the SSL certificate for https. 
 
-Other UDST projects whose documentation uses this domain (e.g. [ChoiceModels](https://docs.udst.org/projects/choicemodels/en/latest)) have to be marked in ReadTheDocs as "subprojects" of the landing page.
+Other UDST projects whose documentation uses this domain (e.g. [ChoiceModels](http://docs.udst.org/projects/choicemodels/en/latest)) have to be marked in ReadTheDocs as "subprojects" of the landing page.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,7 +16,7 @@ Libraries
 .. toctree::
    :maxdepth: 2
    
-   ChoiceModels <https://docs.udst.org/projects/choicemodels/en/latest>
+   ChoiceModels <http://docs.udst.org/projects/choicemodels/en/latest>
    Orca <https://udst.github.io/orca>
    Pandana <http://udst.github.io/pandana>
    Spandex <https://github.com/udst/spandex>


### PR DESCRIPTION
This PR removes "https" from docs.udst.org links on the landing page and in the readme. There's some kind of problem with the SSL certificate.